### PR TITLE
Add AI agent analysis endpoint and UI

### DIFF
--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -7,6 +7,8 @@ const uploadBtn = document.getElementById("uploadBtn");
 const uploadStatus = document.getElementById("uploadStatus");
 const analyzeBtn = document.getElementById("analyzeBtn");
 const analysisResult = document.getElementById("analysisResult");
+const aiAgentBtn = document.getElementById("aiAgentBtn");
+const aiResult = document.getElementById("aiResult");
 
 let uploadedFile = null;
 
@@ -46,12 +48,15 @@ uploadForm.addEventListener("submit", async (e) => {
     uploadedFile = data.filename;
     uploadStatus.textContent = `Uploaded: ${uploadedFile}`;
     analyzeBtn.disabled = false;
+    aiAgentBtn.disabled = false;
 
     // Reset preview
     analysisResult.innerHTML = `<pre>Ready to analyze: ${uploadedFile}</pre>`;
+    aiResult.innerHTML = `<pre>Ready to run AI Agent on: ${uploadedFile}</pre>`;
   } catch (err) {
     uploadedFile = null;
     analyzeBtn.disabled = true;
+    aiAgentBtn.disabled = true;
     showError(analysisResult, err.message || "Upload failed");
     uploadStatus.textContent = "Upload failed";
   } finally {
@@ -94,5 +99,32 @@ analyzeBtn.addEventListener("click", async () => {
     showError(analysisResult, err.message || "Analysis failed");
   } finally {
     setBusy(analyzeBtn, false, "", "Analyze");
+  }
+});
+
+// Handle AI agent analysis
+aiAgentBtn.addEventListener("click", async () => {
+  if (!uploadedFile) {
+    alert("Upload a file first");
+    return;
+  }
+
+  setBusy(aiAgentBtn, true, "Running AI...", "Run AI Agent");
+  aiResult.innerHTML = `<pre>Running AI Agent on ${uploadedFile}…</pre>`;
+
+  try {
+    const res = await fetch("/api/agent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filename: uploadedFile })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || res.statusText);
+
+    aiResult.innerHTML = `<pre>${JSON.stringify(data, null, 2)}</pre>`;
+  } catch (err) {
+    showError(aiResult, err.message || "AI Agent failed");
+  } finally {
+    setBusy(aiAgentBtn, false, "", "Run AI Agent");
   }
 });

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -78,6 +78,16 @@
         <pre>No result yet. Upload a file, then click Analyze.</pre>
       </div>
     </section>
+
+    <section>
+      <h2>3) AI Agent Analysis</h2>
+      <div class="row">
+        <button id="aiAgentBtn" disabled>Run AI Agent</button>
+      </div>
+      <div id="aiResult" style="margin-top:14px;">
+        <pre>No agent result yet. Upload a file, then run AI Agent.</pre>
+      </div>
+    </section>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- add `/api/agent` endpoint that runs DocumentAnalyzerAgent for uploaded files
- expose new **AI Agent Analysis** section in the static UI with a button to invoke the agent
- show JSON result from the agent in a new result panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0ca052188326ac37819440a6d4ed