### PR TITLE
Add gitignore to exclude dependencies and env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore dependency directories
+frontend/node_modules/
+node_modules/
+
+# Ignore Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Environment files
+.env
+


### PR DESCRIPTION
## Summary
- prevent tracking of node modules and other build artifacts with `.gitignore`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be1bfc10288326a6b3307b7a356494