### PR TITLE
feat: add planning advisor AI agent

### DIFF
--- a/backend/static/planning.html
+++ b/backend/static/planning.html
@@ -26,6 +26,7 @@
       <ul>
         <li>Insights & risks summary</li>
         <li>Strategy recommendations</li>
+        <li>AI-based planning advisor suggestions</li>
         <li>SI requirements package</li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- introduce `PlanningAdvisorAgent` and register it with the AI orchestrator
- include the planning advisor in the comprehensive workflow
- mention AI-based planning advisor on the planning page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be1e978a2c8326a3293134ddc0ec94