### PR TITLE
Add mini chat with daily question limit

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import MiniChat from './MiniChat'
 
 export default function App() {
   const [file, setFile] = useState<File | null>(null)
@@ -23,6 +24,7 @@ export default function App() {
       </form>
       <p>{msg}</p>
       <p><a href="/health" target="_blank" rel="noreferrer">Health check</a></p>
+      <MiniChat />
     </div>
   )
 }

--- a/frontend/src/MiniChat.tsx
+++ b/frontend/src/MiniChat.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+
+export default function MiniChat() {
+  const [messages, setMessages] = useState<{ sender: string; text: string }[]>([])
+  const [input, setInput] = useState('')
+  const [disabled, setDisabled] = useState(false)
+
+  async function send() {
+    const question = input.trim()
+    if (!question) return
+    setMessages(m => [...m, { sender: 'You', text: question }])
+    setInput('')
+    try {
+      const res = await fetch('/api/homechat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      })
+      if (res.status === 429) {
+        const data = await res.json()
+        setMessages(m => [...m, { sender: 'System', text: data.detail || 'Limit reached' }])
+        setDisabled(true)
+        return
+      }
+      const data = await res.json()
+      setMessages(m => [...m, { sender: 'Bot', text: data.answer }])
+      if (data.remaining <= 0) setDisabled(true)
+    } catch (err) {
+      setMessages(m => [...m, { sender: 'System', text: 'Error connecting to server' }])
+    }
+  }
+
+  return (
+    <div style={{ border: '1px solid #ccc', padding: 16, marginTop: 24 }}>
+      <h3>Mini Chat</h3>
+      <div style={{ minHeight: 80 }}>
+        {messages.map((m, i) => (
+          <div key={i}>
+            <strong>{m.sender}:</strong> {m.text}
+          </div>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        disabled={disabled}
+        style={{ marginRight: 8 }}
+      />
+      <button onClick={send} disabled={disabled || !input.trim()}>
+        Send
+      </button>
+    </div>
+  )
+}

--- a/requirements-lite.txt
+++ b/requirements-lite.txt
@@ -6,3 +6,4 @@ pypdf==4.3.1
 pandas==2.2.2
 openpyxl==3.1.2
 requests==2.32.3
+redis==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ chromadb==0.5.20
 
 # Utilities
 requests==2.32.3
+redis==5.0.1
 
 # Optional HTML→PDF (needs system libs; see note below)
 weasyprint==62.3


### PR DESCRIPTION
## Summary
- Add Redis-backed question limit to new `/api/homechat` endpoint with session cookie enforcement
- Add simple MiniChat component on the frontend home page
- Include `redis` package in requirements

## Testing
- `pip install redis==5.0.1` *(failed: Could not connect to proxy)*
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be252bf34483269375bf519df023e6