### PR TITLE
Handle optional Excel dependency in analysis

### DIFF
--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -97,16 +97,17 @@ analyzeBtn.addEventListener("click", async () => {
     });
 
     const csvUrl = data.download_url_csv + `?t=${Date.now()}`;
-    const xlsxUrl = data.download_url_xlsx + `?t=${Date.now()}`;
     const rows = typeof data.rows === "number" ? data.rows : "—";
+    let links = `<a class="btn-link" href="${csvUrl}" download>Download CSV</a>`;
+    if (data.download_url_xlsx) {
+      const xlsxUrl = data.download_url_xlsx + `?t=${Date.now()}`;
+      links += `<a class="btn-link" href="${xlsxUrl}" download>Download Excel</a>`;
+    }
 
     analysisResult.innerHTML = `
       <h3>Analysis complete</h3>
       <p>Rows extracted: <strong>${rows}</strong></p>
-      <div>
-        <a class="btn-link" href="${csvUrl}" download>Download CSV</a>
-        <a class="btn-link" href="${xlsxUrl}" download>Download Excel</a>
-      </div>
+      <div>${links}</div>
     `;
   } catch (err) {
     showError(analysisResult, err.message || "Analysis failed");


### PR DESCRIPTION
## Summary
- Avoid crashing when Excel export dependencies are missing by wrapping `to_excel` in try/except
- Return XLSX download link only when the file is generated
- Hide Excel download link in frontend if XLSX is unavailable

## Testing
- `pytest -q`
- `python -m py_compile backend/app/main.py && echo "py_compile successful"`


------
https://chatgpt.com/codex/tasks/task_e_68be2964e93c8326870a5d4fd2e009d9