### PR TITLE
Add compensation planning page

### DIFF
--- a/website/compensation-planning.html
+++ b/website/compensation-planning.html
@@ -119,5 +119,17 @@
             </div>
         </div>
     </section>
+
+    <!-- Planning Guidelines -->
+    <section class="py-20 px-4 bg-gray-50">
+        <div class="max-w-4xl mx-auto">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8 text-center">Planning Guidelines</h2>
+            <ul class="list-disc text-lg text-gray-700 space-y-4 pl-5">
+                <li>Check current salary surveys to benchmark compensation levels.</li>
+                <li>Model plans using performance and payout data from the previous three years.</li>
+                <li>Follow a structured compensation plan design process for consistent outcomes.</li>
+            </ul>
+        </div>
+    </section>
 </body>
 </html>

--- a/website/compensation-planning.html
+++ b/website/compensation-planning.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Compensation Planning - ICM PlanLytics</title>
+    <meta name="description" content="Explore AI-powered compensation planning features from ICM PlanLytics.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .gradient-bg { background: linear-gradient(135deg, #1e40af 0%, #7c3aed 100%); }
+        .feature-card { transition: all 0.3s ease; }
+        .feature-card:hover { transform: translateY(-5px); box-shadow: 0 20px 40px rgba(0,0,0,0.1); }
+    </style>
+</head>
+<body class="bg-gray-50">
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm fixed w-full top-0 z-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center h-16">
+                <div class="flex items-center space-x-3">
+                    <div class="w-10 h-10 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
+                        <span class="text-white font-bold text-sm">ICM</span>
+                    </div>
+                    <div>
+                        <a href="index.html" class="text-xl font-bold text-gray-900">ICM PlanLytics</a>
+                        <span class="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full ml-2">AI BETA</span>
+                    </div>
+                </div>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="index.html#features" class="text-gray-600 hover:text-blue-600 transition-colors">Features</a>
+                    <a href="compensation-planning.html" class="text-blue-600 font-medium">Compensation Planning</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="gradient-bg pt-24 pb-16 px-4">
+        <div class="max-w-4xl mx-auto text-center text-white">
+            <h1 class="text-5xl font-bold mb-6">Compensation Planning</h1>
+            <p class="text-xl text-white/90">
+                Build, model, and optimize compensation plans with intelligent AI guidance.
+            </p>
+        </div>
+    </section>
+
+    <!-- Compensation Planning Features -->
+    <section id="features" class="py-20 px-4 bg-white">
+        <div class="max-w-7xl mx-auto">
+            <div class="text-center mb-16">
+                <h2 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6">Compensation Planning Features</h2>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Core capabilities designed to streamline incentive compensation planning.
+                </p>
+            </div>
+
+            <div class="grid lg:grid-cols-2 gap-12">
+                <!-- Feature 1 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Plan Modeling</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Draft and iterate plan components with real-time validation and AI-driven recommendations.
+                    </p>
+                </div>
+
+                <!-- Feature 2 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Scenario Simulation</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Run what-if scenarios to evaluate plan impact and adjust parameters before launch.
+                    </p>
+                </div>
+
+                <!-- Feature 3 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Workflow Management</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Coordinate approvals and version control with integrated workflows and tracking.
+                    </p>
+                </div>
+
+                <!-- Feature 4 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Analytics & Reporting</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Monitor performance metrics and generate insights with built-in analytics dashboards.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -35,6 +35,7 @@
                 </div>
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="#features" class="text-gray-600 hover:text-blue-600 transition-colors">Features</a>
+                    <a href="compensation-planning.html" class="text-gray-600 hover:text-blue-600 transition-colors">Compensation Planning</a>
                     <a href="#pricing" class="text-gray-600 hover:text-blue-600 transition-colors">Pricing</a>
                     <a href="#demo" class="text-gray-600 hover:text-blue-600 transition-colors">Try Demo</a>
                     <button onclick="scrollToDemo()" class="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors font-medium">


### PR DESCRIPTION
## Summary
- add dedicated compensation planning page with hero section and feature cards
- link new page from navigation bar

## Testing
- `pytest -q`
- `python test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68be2edebb7083268400a147325df1b4