### PR TITLE
Expose compensation planning page and implement core utilities

### DIFF
--- a/app/core/composer.py
+++ b/app/core/composer.py
@@ -4,21 +4,31 @@ from typing import Dict, Any
 from .constraints import validate_plan
 
 
+# In-memory storage for generated plans. This allows other modules to
+# access plan details by ``plan_id`` without a database.
+PLAN_STORE: Dict[str, Dict[str, Any]] = {}
+
+
 def suggest_plan(params: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a stubbed plan suggestion.
+    """Return a basic plan suggestion.
 
     Args:
-        params: Input parameters describing the desired plan.
+        params: Input parameters describing the desired plan. Supports
+            ``sales_goal``, ``num_reps`` and optional ``commission_rate``.
 
     Returns:
         A dictionary with a generated ``plan_id`` and ``details``.
     """
     sales_goal = float(params.get("sales_goal", 0))
     reps = max(int(params.get("num_reps", 1)), 1)
+    commission_rate = float(params.get("commission_rate", 0.1))
     quota_per_rep = sales_goal / reps if reps else 0
-    details = {"quota_per_rep": quota_per_rep}
+    details = {
+        "quota_per_rep": quota_per_rep,
+        "commission_rate": commission_rate,
+        "num_reps": reps,
+    }
     validate_plan(details)
     plan_id = f"plan_{reps}_{int(quota_per_rep)}"
+    PLAN_STORE[plan_id] = details
     return {"plan_id": plan_id, "details": details}
-
-    # TODO: Replace with real plan composition logic.

--- a/app/core/constraints.py
+++ b/app/core/constraints.py
@@ -1,15 +1,21 @@
-"""Stubbed constraint utilities for compensation plans."""
+"""Constraint utilities for compensation plans."""
 from typing import Dict, Any
 
 
 def validate_plan(details: Dict[str, Any]) -> None:
-    """Validate plan details against minimal constraints.
+    """Validate plan details against basic constraints.
 
     Raises:
         ValueError: If a constraint is violated.
     """
-    quota = details.get("quota_per_rep", 0)
+    quota = float(details.get("quota_per_rep", 0))
     if quota <= 0:
         raise ValueError("Quota per rep must be positive")
 
-    # TODO: Implement comprehensive constraint checks.
+    rate = float(details.get("commission_rate", 0))
+    if not (0 < rate <= 1):
+        raise ValueError("Commission rate must be between 0 and 1")
+
+    reps = int(details.get("num_reps", 1))
+    if reps <= 0:
+        raise ValueError("Number of reps must be positive")

--- a/app/core/optimize.py
+++ b/app/core/optimize.py
@@ -1,19 +1,21 @@
 """Optimization utilities for compensation plans."""
 from typing import Dict, Any
 
+from . import composer
+
 
 def optimize_plan(plan_id: str, objectives: Dict[str, float]) -> Dict[str, Any]:
-    """Return a minimally optimized plan.
+    """Adjust plan parameters based on objectives.
 
-    Args:
-        plan_id: Identifier of the plan to adjust.
-        objectives: Optimization targets such as desired margin or rate.
-
-    Returns:
-        A dictionary describing the optimized plan settings.
+    Currently supports a ``target_rate`` which updates the commission rate
+    stored for the plan. The rate is clamped between 0 and 1.
     """
-    target_rate = float(objectives.get("target_rate", 0.1))
-    improved_plan = {"commission_rate": target_rate}
-    return {"plan_id": plan_id, "plan": improved_plan}
+    details = composer.PLAN_STORE.get(plan_id)
+    if details is None:
+        raise ValueError("Unknown plan_id")
 
-    # TODO: Implement real optimization heuristics.
+    target_rate = float(objectives.get("target_rate", details.get("commission_rate", 0.1)))
+    target_rate = max(0.0, min(target_rate, 1.0))
+    details["commission_rate"] = target_rate
+    composer.PLAN_STORE[plan_id] = details
+    return {"plan_id": plan_id, "plan": details}

--- a/app/core/simulate.py
+++ b/app/core/simulate.py
@@ -1,19 +1,17 @@
 """Simulation routines for compensation plans."""
 from typing import Dict, Any
 
+from . import composer
+
 
 def run_simulation(plan_id: str, performance: Dict[str, float]) -> Dict[str, Any]:
     """Simulate payouts for reps under the plan.
 
-    Args:
-        plan_id: Identifier of the plan to simulate.
-        performance: Mapping of rep names to achieved revenue.
-
-    Returns:
-        A dictionary containing calculated payouts per rep and the total.
+    Uses the commission rate stored for the given ``plan_id``. If the plan
+    is unknown, a default rate of 10%% is applied.
     """
-    payouts = {rep: round(rev * 0.1, 2) for rep, rev in performance.items()}
+    details = composer.PLAN_STORE.get(plan_id, {})
+    rate = float(details.get("commission_rate", 0.1))
+    payouts = {rep: round(rev * rate, 2) for rep, rev in performance.items()}
     total = round(sum(payouts.values()), 2)
     return {"plan_id": plan_id, "payouts": payouts, "total_payout": total}
-
-    # TODO: Incorporate plan-specific simulation logic.

--- a/app/export/excel_pack.py
+++ b/app/export/excel_pack.py
@@ -1,13 +1,44 @@
 """Excel export helpers."""
+from io import BytesIO
 from typing import Dict
+
+try:  # Optional dependency
+    from openpyxl import Workbook
+except Exception:  # pragma: no cover - fallback path
+    Workbook = None  # type: ignore
+
+from ..core import composer
 
 
 def generate_workbook(plan_id: str) -> bytes:
-    """Create a minimal workbook for the given plan.
+    """Create a simple workbook for the given plan.
 
-    Returns raw ``.xlsx`` bytes. In real code this would leverage ``openpyxl``
-    or ``xlsxwriter``.
+    If :mod:`openpyxl` is available, an actual XLSX file is produced. Otherwise
+    a CSV-like representation is returned so callers still receive useful
+    content.
     """
-    # TODO: Replace with real Excel generation.
-    content = f"Workbook for {plan_id}"
-    return content.encode()
+    details: Dict | None = composer.PLAN_STORE.get(plan_id)
+
+    if Workbook is None:  # Fallback to CSV bytes
+        lines = [f"Plan ID,{plan_id}"]
+        if details:
+            for k, v in details.items():
+                lines.append(f"{k},{v}")
+        return "\n".join(lines).encode()
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Plan"
+    ws["A1"] = "Plan ID"
+    ws["B1"] = plan_id
+
+    if details:
+        row = 2
+        for key, value in details.items():
+            ws.cell(row=row, column=1, value=key)
+            ws.cell(row=row, column=2, value=value)
+            row += 1
+
+    stream = BytesIO()
+    wb.save(stream)
+    return stream.getvalue()

--- a/app/export/oracle_icm.py
+++ b/app/export/oracle_icm.py
@@ -1,8 +1,25 @@
-"""Oracle ICM export stubs."""
+"""Oracle ICM export helpers."""
+from datetime import datetime
 from typing import Dict, Any
+
+from ..core import composer
 
 
 def export_plan_to_icm(plan_id: str) -> Dict[str, Any]:
-    """Return a stub structure representing an Oracle ICM export."""
-    # TODO: Implement actual Oracle ICM integration.
-    return {"plan_id": plan_id, "status": "exported", "system": "oracle_icm"}
+    """Return a structure representing an Oracle ICM export.
+
+    In lieu of a real API integration this function assembles a payload with
+    the stored plan details and a timestamp, which mirrors what an export
+    operation might produce.
+    """
+    details = composer.PLAN_STORE.get(plan_id)
+    if details is None:
+        raise ValueError("Unknown plan_id")
+
+    return {
+        "plan_id": plan_id,
+        "status": "exported",
+        "system": "oracle_icm",
+        "details": details,
+        "exported_at": datetime.utcnow().isoformat() + "Z",
+    }

--- a/backend/static/compensation-planning.html
+++ b/backend/static/compensation-planning.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Compensation Planning - ICM PlanLytics</title>
+    <meta name="description" content="Explore AI-powered compensation planning features from ICM PlanLytics.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .gradient-bg { background: linear-gradient(135deg, #1e40af 0%, #7c3aed 100%); }
+        .feature-card { transition: all 0.3s ease; }
+        .feature-card:hover { transform: translateY(-5px); box-shadow: 0 20px 40px rgba(0,0,0,0.1); }
+    </style>
+</head>
+<body class="bg-gray-50">
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm fixed w-full top-0 z-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center h-16">
+                <div class="flex items-center space-x-3">
+                    <div class="w-10 h-10 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
+                        <span class="text-white font-bold text-sm">ICM</span>
+                    </div>
+                    <div>
+                        <a href="index.html" class="text-xl font-bold text-gray-900">ICM PlanLytics</a>
+                        <span class="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full ml-2">AI BETA</span>
+                    </div>
+                </div>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="index.html#features" class="text-gray-600 hover:text-blue-600 transition-colors">Features</a>
+                    <a href="compensation-planning.html" class="text-blue-600 font-medium">Compensation Planning</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="gradient-bg pt-24 pb-16 px-4">
+        <div class="max-w-4xl mx-auto text-center text-white">
+            <h1 class="text-5xl font-bold mb-6">Compensation Planning</h1>
+            <p class="text-xl text-white/90">
+                Build, model, and optimize compensation plans with intelligent AI guidance.
+            </p>
+        </div>
+    </section>
+
+    <!-- Compensation Planning Features -->
+    <section id="features" class="py-20 px-4 bg-white">
+        <div class="max-w-7xl mx-auto">
+            <div class="text-center mb-16">
+                <h2 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6">Compensation Planning Features</h2>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Core capabilities designed to streamline incentive compensation planning.
+                </p>
+            </div>
+
+            <div class="grid lg:grid-cols-2 gap-12">
+                <!-- Feature 1 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Plan Modeling</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Draft and iterate plan components with real-time validation and AI-driven recommendations.
+                    </p>
+                </div>
+
+                <!-- Feature 2 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Scenario Simulation</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Run what-if scenarios to evaluate plan impact and adjust parameters before launch.
+                    </p>
+                </div>
+
+                <!-- Feature 3 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Workflow Management</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Coordinate approvals and version control with integrated workflows and tracking.
+                    </p>
+                </div>
+
+                <!-- Feature 4 -->
+                <div class="feature-card bg-gray-50 p-8 rounded-2xl">
+                    <div class="flex items-center mb-6">
+                        <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mr-4">
+                            <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-2xl font-semibold text-gray-900">Analytics & Reporting</h3>
+                    </div>
+                    <p class="text-gray-600 mb-6 text-lg">
+                        Monitor performance metrics and generate insights with built-in analytics dashboards.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Planning Guidelines -->
+    <section class="py-20 px-4 bg-gray-50">
+        <div class="max-w-4xl mx-auto">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8 text-center">Planning Guidelines</h2>
+            <ul class="list-disc text-lg text-gray-700 space-y-4 pl-5">
+                <li>Check current salary surveys to benchmark compensation levels.</li>
+                <li>Model plans using performance and payout data from the previous three years.</li>
+                <li>Follow a structured compensation plan design process for consistent outcomes.</li>
+            </ul>
+        </div>
+    </section>
+</body>
+</html>

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -40,7 +40,7 @@
 </head>
 <body>
   <header>
-    <img class="brand-logo" src="/static/LogoPlanytics.png" alt="PlanLytics logo" />
+    <img class="brand-logo" src="/static/LogoPlanlytics.png" alt="PlanLytics logo" />
     <div>
       <h1>PlanLytics</h1>
       <p class="tagline">
@@ -53,7 +53,7 @@
       </ul>
       <nav class="head-nav">
         <a href="/">Home</a>
-        <a href="/planning.html">AI-Powered Compensation Planning</a>
+        <a href="/compensation-planning.html">AI-Powered Compensation Planning</a>
         <a href="/docs">API Docs</a>
       </nav>
     </div>

--- a/backend/static/planning.html
+++ b/backend/static/planning.html
@@ -5,11 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI-Powered Compensation Planning — PlanLytics</title>
   <meta name="description" content="Plan planning assistance: strategy, risks, and SI-ready requirements & setups." />
-  <link rel="stylesheet" href="/static/styles.css" />
 </head>
 <body>
   <header>
-    <img class="brand-logo" src="/static/LogoPlanytics.png" alt="PlanLytics logo" />
+    <img class="brand-logo" src="/static/LogoPlanlytics.png" alt="PlanLytics logo" />
     <div>
       <h1>AI-Powered Compensation Planning</h1>
       <p class="tagline">Design smarter plans with AI—surface risks, dependencies, and SI-ready deliverables.</p>

--- a/test_config.py
+++ b/test_config.py
@@ -1,6 +1,11 @@
 # test_config.py
 import os
-from dotenv import load_dotenv
+
+try:  # Optional dependency
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - module may be absent
+    def load_dotenv() -> bool:  # type: ignore
+        return False
 
 load_dotenv()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,42 @@
+import pytest
+from io import BytesIO
+
+try:
+    from openpyxl import load_workbook  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    load_workbook = None
+
+from app.core import composer, simulate, optimize, constraints
+from app.export import excel_pack, oracle_icm
+
+
+def test_plan_lifecycle():
+    plan = composer.suggest_plan({"sales_goal": 100000, "num_reps": 5, "commission_rate": 0.1})
+    plan_id = plan["plan_id"]
+
+    # ensure details stored
+    assert composer.PLAN_STORE[plan_id]["quota_per_rep"] == 20000
+
+    perf = {"alice": 50000}
+    result = simulate.run_simulation(plan_id, perf)
+    assert result["payouts"]["alice"] == 5000.0
+
+    optimize.optimize_plan(plan_id, {"target_rate": 0.2})
+    result = simulate.run_simulation(plan_id, perf)
+    assert result["payouts"]["alice"] == 10000.0
+
+    payload = oracle_icm.export_plan_to_icm(plan_id)
+    assert payload["details"]["commission_rate"] == 0.2
+
+    workbook_bytes = excel_pack.generate_workbook(plan_id)
+    assert isinstance(workbook_bytes, (bytes, bytearray))
+    if load_workbook:
+        wb = load_workbook(BytesIO(workbook_bytes))
+        assert wb.active["B1"].value == plan_id
+
+
+def test_validate_plan_rejects_invalid():
+    with pytest.raises(ValueError):
+        constraints.validate_plan({"quota_per_rep": -1, "commission_rate": 0.1})
+    with pytest.raises(ValueError):
+        constraints.validate_plan({"quota_per_rep": 100, "commission_rate": 0})


### PR DESCRIPTION
## Summary
- Serve new `compensation-planning.html` page and fix static asset paths
- Implement plan storage with validation, optimization, simulation and export helpers
- Provide Excel export with CSV fallback and add unit tests for core workflow

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2ebe64e88326956fdfcf24b3c6ca