### PR TITLE
Add sales contact email to website

### DIFF
--- a/website/compensation-planning.html
+++ b/website/compensation-planning.html
@@ -130,6 +130,25 @@
                 <li>Follow a structured compensation plan design process for consistent outcomes.</li>
             </ul>
         </div>
-    </section>
-</body>
-</html>
+  </section>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-16 px-4">
+        <div class="max-w-7xl mx-auto text-center">
+            <div class="flex items-center justify-center space-x-3 mb-6">
+                <div class="w-10 h-10 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
+                    <span class="text-white font-bold text-sm">ICM</span>
+                </div>
+                <span class="text-2xl font-bold">ICM PlanLytics</span>
+            </div>
+            <p class="text-gray-300 mb-6 max-w-md mx-auto">
+                AI-powered ICM analysis platform. Transform your compensation plans with intelligent automation.
+            </p>
+            <div class="text-gray-400 text-sm">
+                © 2025 ICM PlanLytics. All rights reserved.<br>
+                Contact us: <a href="mailto:sales@icm-planlytics.com" class="underline hover:text-white">sales@icm-planlytics.com</a>
+            </div>
+        </div>
+    </footer>
+  </body>
+  </html>

--- a/website/index.html
+++ b/website/index.html
@@ -283,7 +283,8 @@
                 AI-powered ICM analysis platform. Transform your compensation plans with intelligent automation.
             </p>
             <div class="text-gray-400 text-sm">
-                © 2025 ICM PlanLytics. All rights reserved.
+                © 2025 ICM PlanLytics. All rights reserved.<br>
+                Contact us: <a href="mailto:sales@icm-planlytics.com" class="underline hover:text-white">sales@icm-planlytics.com</a>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- add sales contact email to main site footer
- include contact footer in compensation planning page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf30d2bd5c832692348f270687c85a